### PR TITLE
feat: key vault secrets provider

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.63.0"
   constraints = "3.63.0"
   hashes = [
+    "h1:/ZftiSeprgN9eXNsGpeTqW+op0Ge11c2o9PdEYz39bk=",
     "h1:PT0lfMSxYAL+Pcu5BwWiWDLq6u/mzx1O/dVfxFotDDU=",
     "zh:0bb8263de0abf1a7457168673f9fcf7e404ae59d03d0e8eda91f1e024f8d9253",
     "zh:24dd5883c95801f2d4a88be22b9a3bb4e20de7b6b65e8b7cc90b12a0895d7adf",
@@ -23,9 +24,10 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.10.1"
-  constraints = ">= 2.5.0, 2.10.1"
+  constraints = "2.10.1"
   hashes = [
     "h1:ctDhNJU4tEcyoUgPzwKuJmbDIqUl25mCY+s/lVHP6Sg=",
+    "h1:rssAXPIBWhumMtToGhh63w1euKOgVOi7+9LK6qZtDUQ=",
     "zh:0717312baed39fb0a00576297241b69b419880cad8771bf72dec97ebdc96b200",
     "zh:0e0e287b4e8429a0700143c8159764502eba0b33b1d094bf0d4ef4d93c7802cb",
     "zh:4f74605377dab4065aaad35a2c5fa6186558c6e2e57b9058bdc8a62cf91857b9",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version     = "3.3.0"
   constraints = "3.3.0"
   hashes = [
+    "h1:O2VLKCxxAgaFRPnhRuz/VOsP5HzQdQm9YAi848kvImg=",
     "h1:pK/CC2NlpUbL4x3R386uxfS80HodJXtGREg0k2ABukw=",
     "zh:27d101f4c089d1e367bbbbb3f260fc7d52f63559a4424c08633e566863c951b2",
     "zh:37860671324229f52a7d82eea88a31fe24321297fd699d879de5b6cf6aae086c",
@@ -63,8 +66,9 @@ provider "registry.terraform.io/hashicorp/http" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.21.1"
-  constraints = ">= 2.0.1, 2.21.1"
+  constraints = "2.21.1"
   hashes = [
+    "h1:I1qWLUFmB0Z8+3CX+XzJtkgiAOYQ1nHlLN9lFcPf+zc=",
     "h1:gP8IU3gFfXYRfGZr5Qws9JryZsOGsluAVpiAoZW7eo0=",
     "zh:156a437d7edd6813e9cb7bdff16ebce28cec08b07ba1b0f5e9cec029a217bc27",
     "zh:1a21c255d8099e303560e252579c54e99b5f24f2efde772c7e39502c62472605",
@@ -86,6 +90,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = "2.4.0"
   hashes = [
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -105,6 +110,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/aks/k8s.tf
+++ b/aks/k8s.tf
@@ -10,6 +10,10 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   role_based_access_control_enabled = true
   http_application_routing_enabled  = false // replaced by az aks approuting enable -g <ResourceGroupName> -n <ClusterName>
 
+  key_vault_secrets_provider {
+    secret_rotation_enabled = true
+  }
+
   azure_active_directory_role_based_access_control {
     managed            = true
     azure_rbac_enabled = true

--- a/keyvault/keyvault.tf
+++ b/keyvault/keyvault.tf
@@ -81,5 +81,18 @@ resource "azurerm_key_vault" "keyvalue" {
       storage_permissions = []
       tenant_id           = var.tenant_id
     },
+    {
+      certificate_permissions = []
+      key_permissions = [
+        "Get"
+      ]
+      object_id = "43fab6a8-439d-4f98-b387-682df65783f8" # Key Vault Secrets Provider
+      secret_permissions = [
+        "Get"
+      ]
+      application_id      = null
+      storage_permissions = []
+      tenant_id           = var.tenant_id
+    },
   ]
 }


### PR DESCRIPTION
Apparently it's that easy
A titolo informativo pianto qui l'esempio di manifest k8s per avere accesso ai secret nel keyvault creato adattando gli esempi di Microsoft
```yaml
# This is a sample pod definition for using SecretProviderClass and the user-assigned identity to access your key vault

apiVersion: secrets-store.csi.x-k8s.io/v1
kind: SecretProviderClass
metadata:
  name: sc-demo-keyvault-csi
spec:
  provider: azure
  parameters:
    usePodIdentity: "false"
    useVMManagedIdentity: "true" # Set to true for using managed identity
    userAssignedIdentityID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # Set the clientID of the user-assigned managed identity to use
    keyvaultName: kv-polinetwork # Set to the name of your key vault
    objects: |
      array:
        - |
          objectName: ExampleSecret            # keyvault secret name
          objectType: secret
    tenantId: xxxxxxxxxxx-xxxxxxxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxxx # The tenant ID of the key vault
---
kind: Pod
apiVersion: v1
metadata:
  name: sc-demo-keyvault-csi
spec:
  containers:
    - name: busybox
      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
      command:
        - "/bin/sleep"
        - "10000"
      volumeMounts:
        - name: secrets-store01-inline
          mountPath: "/mnt/secrets-store"
          readOnly: true
      resources:
        requests:
          cpu: 100m
          memory: 128Mi
        limits:
          cpu: 250m
          memory: 256Mi
  volumes:
    - name: secrets-store01-inline
      csi:
        driver: secrets-store.csi.k8s.io
        readOnly: true
        volumeAttributes:
          secretProviderClass: "sc-demo-keyvault-csi"

```
copiando questo manifest in un file `pod.yml` si può testare con
```sh
kubectl apply -f pod.yaml
```
```sh
kubectl exec sc-demo-keyvault-csi -- cat /mnt/secrets-store/ExampleSecret
```
```sh
kubectl delete -f pod.yaml
```

Nell'esempio il secret è montato come volume, ma può anche essere montato nell'env passando dai Kubernetes secrets (vedi https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-configuration-options#sync-mounted-content-with-a-kubernetes-secret)
Non sono sicuro che questo terraform sia ottimale, immagino che l'identity (il cui object ID è hardcoded in `keyvault.tf` e il client ID deve essere passato al SecretProviderClass di cui sopra, che sono tutte informazioni non eccessivamente sensibili a quanto pare) possa essere definita direttamente dentro terraform, però noto che è solo uno dei tanti ID di cui vengono specificati i permessi in questo modo, so good enough i guess 🤷‍♂️

Also non c'entra molto con questo ma dovremmo aggiornare le versioni dei provider in terraform perché quelle che abbiamo sono ancient, a vscode non piace questa cosa